### PR TITLE
Add HarmonyOS front-end ID card rectifier tool

### DIFF
--- a/tools/id-card-rectifier/index.html
+++ b/tools/id-card-rectifier/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>身份证裁剪拉直工具 - HarmonyOS Web</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="app-header">
+        <h1>身份证裁剪拉直一体化工具</h1>
+        <p class="subtitle">为 HarmonyOS 打造的纯前端离线小工具，支持身份证照片裁剪与透视矫正。</p>
+    </header>
+
+    <main class="app-shell">
+        <section class="panel controls">
+            <h2>步骤</h2>
+            <ol>
+                <li>选择或拖拽身份证图片至下方画布。</li>
+                <li>拖动四个角点对齐身份证边角，可使用放大镜辅助。</li>
+                <li>点击“生成预览”完成裁剪及拉直，可下载高清 PNG。</li>
+            </ol>
+
+            <div class="input-group">
+                <label class="file-input" for="photoInput">
+                    <span>📄 选择身份证图片</span>
+                    <input type="file" id="photoInput" accept="image/*">
+                </label>
+                <button id="resetButton" class="secondary" type="button">重置角点</button>
+            </div>
+
+            <div class="export-group">
+                <button id="previewButton" type="button">生成预览</button>
+                <button id="downloadButton" class="ghost" type="button" disabled>下载 PNG</button>
+            </div>
+
+            <aside class="tips">
+                <h3>使用技巧</h3>
+                <ul>
+                    <li>在 HarmonyOS 浏览器中可直接离线使用。</li>
+                    <li>支持多指缩放页面，便于精确拖动角点。</li>
+                    <li>若身份证倒置，可先旋转手机或在外部相册调整方向。</li>
+                </ul>
+            </aside>
+        </section>
+
+        <section class="panel workspace">
+            <h2>裁剪调整</h2>
+            <div class="canvas-wrapper">
+                <canvas id="editCanvas" width="840" height="560" aria-label="编辑画布"></canvas>
+                <div class="magnifier" id="magnifier" hidden>
+                    <canvas id="magnifierCanvas" width="160" height="160"></canvas>
+                </div>
+                <p class="placeholder" id="placeholder">请先选择图片</p>
+            </div>
+        </section>
+
+        <section class="panel preview">
+            <h2>拉直预览</h2>
+            <canvas id="previewCanvas" width="600" height="380" aria-label="预览画布"></canvas>
+        </section>
+    </main>
+
+    <footer class="app-footer">
+        <p>所有计算均在本地浏览器完成，安全、快速且无需任何后端服务。</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/id-card-rectifier/script.js
+++ b/tools/id-card-rectifier/script.js
@@ -1,0 +1,363 @@
+const photoInput = document.getElementById('photoInput');
+const editCanvas = document.getElementById('editCanvas');
+const editCtx = editCanvas.getContext('2d');
+const previewCanvas = document.getElementById('previewCanvas');
+const previewCtx = previewCanvas.getContext('2d');
+const previewButton = document.getElementById('previewButton');
+const downloadButton = document.getElementById('downloadButton');
+const resetButton = document.getElementById('resetButton');
+const placeholder = document.getElementById('placeholder');
+const magnifier = document.getElementById('magnifier');
+const magnifierCanvas = document.getElementById('magnifierCanvas');
+const magnifierCtx = magnifierCanvas.getContext('2d');
+
+const handleRadius = 12;
+const magnetRadiusSq = 26 * 26;
+
+let image = null;
+let sourceCanvas = null;
+let sourceCtx = null;
+let handles = [];
+let activeHandleIndex = -1;
+let editScale = 1;
+let editOffset = { x: 0, y: 0 };
+let pointerId = null;
+
+photoInput.addEventListener('change', (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => loadImage(reader.result);
+    reader.readAsDataURL(file);
+});
+
+resetButton.addEventListener('click', () => {
+    if (!image) return;
+    resetHandles();
+    renderEditCanvas();
+});
+
+previewButton.addEventListener('click', () => {
+    if (!image) return;
+    generatePreview();
+});
+
+downloadButton.addEventListener('click', () => {
+    const url = previewCanvas.toDataURL('image/png');
+    const link = document.createElement('a');
+    link.href = url;
+    const timestamp = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14);
+    link.download = `id-card-${timestamp}.png`;
+    link.click();
+});
+
+function loadImage(url) {
+    const img = new Image();
+    img.onload = () => {
+        image = img;
+        placeholder.hidden = true;
+        setupSourceCanvas();
+        computeEditScale();
+        resetHandles();
+        renderEditCanvas();
+        previewCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
+        downloadButton.disabled = true;
+    };
+    img.onerror = () => alert('加载图片失败，请尝试重新选择');
+    img.src = url;
+}
+
+function setupSourceCanvas() {
+    sourceCanvas = document.createElement('canvas');
+    sourceCanvas.width = image.naturalWidth;
+    sourceCanvas.height = image.naturalHeight;
+    sourceCtx = sourceCanvas.getContext('2d');
+    sourceCtx.drawImage(image, 0, 0);
+}
+
+function computeEditScale() {
+    const padding = 32;
+    const availableWidth = editCanvas.width - padding;
+    const availableHeight = editCanvas.height - padding;
+    const scale = Math.min(availableWidth / image.naturalWidth, availableHeight / image.naturalHeight);
+    editScale = scale;
+    editOffset = {
+        x: (editCanvas.width - image.naturalWidth * scale) / 2,
+        y: (editCanvas.height - image.naturalHeight * scale) / 2,
+    };
+}
+
+function resizeWorkspace() {
+    if (!image) return;
+    computeEditScale();
+    renderEditCanvas();
+}
+
+function resetHandles() {
+    handles = [
+        { x: 0, y: 0 },
+        { x: image.naturalWidth, y: 0 },
+        { x: image.naturalWidth, y: image.naturalHeight },
+        { x: 0, y: image.naturalHeight },
+    ];
+}
+
+function toDisplayCoordinates(point) {
+    return {
+        x: point.x * editScale + editOffset.x,
+        y: point.y * editScale + editOffset.y,
+    };
+}
+
+function toImageCoordinates(point) {
+    return {
+        x: Math.min(Math.max((point.x - editOffset.x) / editScale, 0), image.naturalWidth),
+        y: Math.min(Math.max((point.y - editOffset.y) / editScale, 0), image.naturalHeight),
+    };
+}
+
+function renderEditCanvas() {
+    editCtx.clearRect(0, 0, editCanvas.width, editCanvas.height);
+    if (!image) return;
+
+    editCtx.drawImage(
+        image,
+        editOffset.x,
+        editOffset.y,
+        image.naturalWidth * editScale,
+        image.naturalHeight * editScale
+    );
+
+    const displayPoints = handles.map(toDisplayCoordinates);
+
+    editCtx.save();
+    editCtx.lineWidth = 2;
+    editCtx.strokeStyle = 'rgba(10, 89, 247, 0.9)';
+    editCtx.fillStyle = 'rgba(10, 89, 247, 0.18)';
+
+    editCtx.beginPath();
+    editCtx.moveTo(displayPoints[0].x, displayPoints[0].y);
+    for (let i = 1; i < displayPoints.length; i++) {
+        editCtx.lineTo(displayPoints[i].x, displayPoints[i].y);
+    }
+    editCtx.closePath();
+    editCtx.fill();
+    editCtx.stroke();
+
+    for (const point of displayPoints) {
+        const gradient = editCtx.createRadialGradient(point.x, point.y, 2, point.x, point.y, handleRadius);
+        gradient.addColorStop(0, '#fff');
+        gradient.addColorStop(1, '#0a59f7');
+        editCtx.fillStyle = gradient;
+        editCtx.beginPath();
+        editCtx.arc(point.x, point.y, handleRadius, 0, Math.PI * 2);
+        editCtx.fill();
+        editCtx.strokeStyle = '#fff';
+        editCtx.lineWidth = 2;
+        editCtx.stroke();
+    }
+    editCtx.restore();
+}
+
+function getHandleIndexAtPosition(x, y) {
+    const displayPoints = handles.map(toDisplayCoordinates);
+    for (let i = 0; i < displayPoints.length; i++) {
+        const point = displayPoints[i];
+        const distSq = (point.x - x) ** 2 + (point.y - y) ** 2;
+        if (distSq <= magnetRadiusSq) return i;
+    }
+    return -1;
+}
+
+function updateMagnifier(clientX, clientY, imagePoint) {
+    if (!image) return;
+    const rect = editCanvas.getBoundingClientRect();
+    const canvasPoint = {
+        x: ((clientX - rect.left) * editCanvas.width) / rect.width,
+        y: ((clientY - rect.top) * editCanvas.height) / rect.height,
+    };
+
+    const magnifierSize = magnifierCanvas.width;
+    const zoom = 3;
+    const halfViewport = magnifierSize / (2 * zoom);
+    const maxSourceX = Math.max(0, sourceCanvas.width - magnifierSize / zoom);
+    const maxSourceY = Math.max(0, sourceCanvas.height - magnifierSize / zoom);
+    const sourceX = clamp(imagePoint.x - halfViewport, 0, maxSourceX);
+    const sourceY = clamp(imagePoint.y - halfViewport, 0, maxSourceY);
+
+    magnifierCtx.clearRect(0, 0, magnifierSize, magnifierSize);
+    magnifierCtx.drawImage(
+        sourceCanvas,
+        sourceX,
+        sourceY,
+        magnifierSize / zoom,
+        magnifierSize / zoom,
+        0,
+        0,
+        magnifierSize,
+        magnifierSize
+    );
+    magnifierCtx.strokeStyle = 'rgba(10, 89, 247, 0.7)';
+    magnifierCtx.lineWidth = 2;
+    magnifierCtx.strokeRect(0, 0, magnifierSize, magnifierSize);
+
+    magnifier.style.left = `${canvasPoint.x / editCanvas.width * 100}%`;
+    magnifier.style.top = `${canvasPoint.y / editCanvas.height * 100}%`;
+    magnifier.hidden = false;
+}
+
+function hideMagnifier() {
+    magnifier.hidden = true;
+}
+
+editCanvas.addEventListener('pointerdown', (event) => {
+    if (!image) return;
+    pointerId = event.pointerId;
+    const rect = editCanvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) * editCanvas.width) / rect.width;
+    const y = ((event.clientY - rect.top) * editCanvas.height) / rect.height;
+    activeHandleIndex = getHandleIndexAtPosition(x, y);
+    if (activeHandleIndex >= 0) {
+        editCanvas.setPointerCapture(pointerId);
+        const imgPoint = toImageCoordinates({ x, y });
+        updateMagnifier(event.clientX, event.clientY, imgPoint);
+    }
+});
+
+editCanvas.addEventListener('pointermove', (event) => {
+    if (!image || activeHandleIndex < 0 || event.pointerId !== pointerId) return;
+    const rect = editCanvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) * editCanvas.width) / rect.width;
+    const y = ((event.clientY - rect.top) * editCanvas.height) / rect.height;
+    const imgPoint = toImageCoordinates({ x, y });
+    handles[activeHandleIndex] = imgPoint;
+    updateMagnifier(event.clientX, event.clientY, imgPoint);
+    renderEditCanvas();
+});
+
+editCanvas.addEventListener('pointerup', endDrag);
+editCanvas.addEventListener('pointercancel', endDrag);
+
+function endDrag(event) {
+    if (event.pointerId !== pointerId) return;
+    if (editCanvas.hasPointerCapture(pointerId)) {
+        editCanvas.releasePointerCapture(pointerId);
+    }
+    pointerId = null;
+    activeHandleIndex = -1;
+    hideMagnifier();
+}
+
+function generatePreview() {
+    const top = distance(handles[0], handles[1]);
+    const bottom = distance(handles[3], handles[2]);
+    const left = distance(handles[0], handles[3]);
+    const right = distance(handles[1], handles[2]);
+
+    const targetWidth = Math.max(top, bottom, 1);
+    const targetHeight = Math.max(left, right, 1);
+
+    const aspect = targetWidth / targetHeight;
+    const width = Math.min(1200, Math.max(480, Math.round(targetWidth)));
+    const height = Math.max(1, Math.round(width / aspect));
+
+    previewCanvas.width = width;
+    previewCanvas.height = height;
+
+    const sourceData = sourceCtx.getImageData(0, 0, sourceCanvas.width, sourceCanvas.height);
+    const destData = previewCtx.createImageData(width, height);
+    const src = sourceData.data;
+    const dst = destData.data;
+
+    for (let y = 0; y < height; y++) {
+        const v = height === 1 ? 0 : y / (height - 1);
+        for (let x = 0; x < width; x++) {
+            const u = width === 1 ? 0 : x / (width - 1);
+            const point = bilinearInterpolate(handles, u, v);
+            const color = sampleBilinear(src, sourceCanvas.width, sourceCanvas.height, point.x, point.y);
+            const index = (y * width + x) * 4;
+            dst[index] = color[0];
+            dst[index + 1] = color[1];
+            dst[index + 2] = color[2];
+            dst[index + 3] = color[3];
+        }
+    }
+
+    previewCtx.putImageData(destData, 0, 0);
+    downloadButton.disabled = false;
+}
+
+function bilinearInterpolate(points, u, v) {
+    const [tl, tr, br, bl] = points;
+    const top = lerpPoint(tl, tr, u);
+    const bottom = lerpPoint(bl, br, u);
+    return lerpPoint(top, bottom, v);
+}
+
+function lerpPoint(a, b, t) {
+    return {
+        x: a.x + (b.x - a.x) * t,
+        y: a.y + (b.y - a.y) * t,
+    };
+}
+
+function sampleBilinear(data, width, height, x, y) {
+    const x0 = Math.floor(x);
+    const y0 = Math.floor(y);
+    const x1 = Math.min(x0 + 1, width - 1);
+    const y1 = Math.min(y0 + 1, height - 1);
+
+    const dx = x - x0;
+    const dy = y - y0;
+
+    const c00 = getPixel(data, width, x0, y0);
+    const c10 = getPixel(data, width, x1, y0);
+    const c01 = getPixel(data, width, x0, y1);
+    const c11 = getPixel(data, width, x1, y1);
+
+    const r = bilerp(c00[0], c10[0], c01[0], c11[0], dx, dy);
+    const g = bilerp(c00[1], c10[1], c01[1], c11[1], dx, dy);
+    const b = bilerp(c00[2], c10[2], c01[2], c11[2], dx, dy);
+    const a = bilerp(c00[3], c10[3], c01[3], c11[3], dx, dy);
+
+    return [r, g, b, a];
+}
+
+function bilerp(c00, c10, c01, c11, dx, dy) {
+    const top = c00 * (1 - dx) + c10 * dx;
+    const bottom = c01 * (1 - dx) + c11 * dx;
+    return Math.round(top * (1 - dy) + bottom * dy);
+}
+
+function getPixel(data, width, x, y) {
+    const index = (y * width + x) * 4;
+    return [data[index], data[index + 1], data[index + 2], data[index + 3]];
+}
+
+function distance(a, b) {
+    return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+// 允许拖拽文件到画布
+editCanvas.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+});
+
+editCanvas.addEventListener('drop', (event) => {
+    event.preventDefault();
+    const file = event.dataTransfer.files?.[0];
+    if (file && file.type.startsWith('image/')) {
+        const reader = new FileReader();
+        reader.onload = () => loadImage(reader.result);
+        reader.readAsDataURL(file);
+    }
+});
+
+window.addEventListener('resize', () => {
+    window.requestAnimationFrame(resizeWorkspace);
+});

--- a/tools/id-card-rectifier/style.css
+++ b/tools/id-card-rectifier/style.css
@@ -1,0 +1,197 @@
+:root {
+    color-scheme: light dark;
+    --bg: #f5f7fb;
+    --panel: rgba(255, 255, 255, 0.92);
+    --border: rgba(18, 28, 45, 0.12);
+    --accent: #0a59f7;
+    --accent-weak: rgba(10, 89, 247, 0.14);
+    --text: #1b1f2a;
+    --text-weak: #4f566b;
+    --success: #0fb574;
+    font-family: "HarmonyOS Sans", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: linear-gradient(160deg, rgba(10, 89, 247, 0.04), rgba(15, 181, 116, 0.04));
+    color: var(--text);
+}
+
+.app-header,
+.app-footer {
+    padding: 24px clamp(16px, 6vw, 64px);
+    text-align: center;
+}
+
+.app-header h1 {
+    margin-bottom: 8px;
+    font-size: clamp(1.6rem, 2.4vw, 2.4rem);
+}
+
+.subtitle {
+    margin: 0 auto;
+    max-width: 720px;
+    color: var(--text-weak);
+}
+
+.app-shell {
+    display: grid;
+    gap: 20px;
+    padding: 0 clamp(16px, 6vw, 64px) 32px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.panel {
+    background: var(--panel);
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: 0 12px 32px rgba(15, 35, 66, 0.08);
+    border: 1px solid var(--border);
+    backdrop-filter: blur(18px);
+}
+
+.panel h2 {
+    margin-top: 0;
+    font-size: 1.2rem;
+}
+
+.controls ol {
+    padding-left: 20px;
+    color: var(--text-weak);
+}
+
+.file-input {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 18px;
+    border-radius: 16px;
+    background: var(--accent);
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 10px 24px rgba(10, 89, 247, 0.25);
+}
+
+.file-input:hover {
+    transform: translateY(-1px);
+}
+
+.file-input input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.input-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-block: 18px;
+}
+
+button {
+    border: none;
+    border-radius: 16px;
+    padding: 12px 20px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+}
+
+button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+button:not(:disabled):hover {
+    transform: translateY(-1px);
+}
+
+#previewButton {
+    background: var(--success);
+    color: #fff;
+    box-shadow: 0 12px 24px rgba(15, 181, 116, 0.25);
+}
+
+.secondary {
+    background: var(--accent-weak);
+    color: var(--accent);
+}
+
+.ghost {
+    background: transparent;
+    color: var(--accent);
+    border: 1px dashed rgba(10, 89, 247, 0.45);
+}
+
+.tips ul {
+    margin: 0;
+    padding-left: 20px;
+    color: var(--text-weak);
+}
+
+.canvas-wrapper {
+    position: relative;
+    width: 100%;
+    min-height: 280px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: repeating-linear-gradient(135deg, rgba(10, 89, 247, 0.08), rgba(10, 89, 247, 0.08) 12px, transparent 12px, transparent 24px);
+    border-radius: 20px;
+    border: 1px dashed rgba(10, 89, 247, 0.15);
+}
+
+#editCanvas {
+    width: min(100%, 840px);
+    height: auto;
+    border-radius: 16px;
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.placeholder {
+    position: absolute;
+    color: var(--text-weak);
+    text-align: center;
+    font-size: 1rem;
+}
+
+.magnifier {
+    position: absolute;
+    width: 160px;
+    height: 160px;
+    border-radius: 20px;
+    border: 2px solid var(--accent);
+    overflow: hidden;
+    box-shadow: 0 10px 30px rgba(10, 89, 247, 0.25);
+    backdrop-filter: blur(16px);
+}
+
+#previewCanvas {
+    width: 100%;
+    max-width: 520px;
+    background: #fff;
+    border-radius: 16px;
+    border: 1px solid rgba(15, 35, 66, 0.12);
+}
+
+.app-footer {
+    color: var(--text-weak);
+}
+
+@media (max-width: 720px) {
+    .app-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .canvas-wrapper {
+        min-height: 220px;
+    }
+}


### PR DESCRIPTION
## Summary
- add a HarmonyOS-styled standalone front-end for ID card cropping and perspective correction
- implement draggable corner handles with magnifier assistance and bilinear-resampled output preview
- provide preview generation and PNG download without any backend dependency

## Testing
- not run (static front-end asset)


------
https://chatgpt.com/codex/tasks/task_e_68ccd0db1d508324974ffb96bb9338d6